### PR TITLE
Added support for python 3.x. Fixes #3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "3.3"
+  - "3.4"
 
 # command to run tests
 script: python setup.py test

--- a/commentjson/__init__.py
+++ b/commentjson/__init__.py
@@ -1,5 +1,6 @@
-from commentjson import dump
-from commentjson import dumps
-from commentjson import JSONLibraryException
-from commentjson import load
-from commentjson import loads
+__all__ = ['dump', 'dumps', 'load', 'loads', 'JSONLibraryException']
+
+try: # for python 2.x
+	from commentjson import dump, dumps, load, loads, JSONLibraryException
+except ImportError: # python 3.x
+	from .commentjson import dump, dumps, load, loads, JSONLibraryException

--- a/commentjson/commentjson.py
+++ b/commentjson/commentjson.py
@@ -59,8 +59,8 @@ def loads(text, **kwargs):
 
     try:
         return json.loads('\n'.join(lines), **kwargs)
-    except Exception, e:
-        raise JSONLibraryException(e.message)
+    except Exception as e:
+        raise JSONLibraryException(str(e))
 
 
 def dumps(obj, **kwargs):
@@ -76,8 +76,8 @@ def dumps(obj, **kwargs):
 
     try:
         return json.dumps(obj, **kwargs)
-    except Exception, e:
-        raise JSONLibraryException(e.message)
+    except Exception as e:
+        raise JSONLibraryException(str(e))
 
 
 def load(fp, **kwargs):
@@ -94,8 +94,8 @@ def load(fp, **kwargs):
 
     try:
         return loads(fp.read(), **kwargs)
-    except Exception, e:
-        raise JSONLibraryException(e.message)
+    except Exception as e:
+        raise JSONLibraryException(str(e))
 
 
 def dump(obj, fp, **kwargs):
@@ -113,5 +113,5 @@ def dump(obj, fp, **kwargs):
 
     try:
         json.dump(obj, fp, **kwargs)
-    except Exception, e:
-        raise JSONLibraryException(e.message)
+    except Exception as e:
+        raise JSONLibraryException(str(e))

--- a/commentjson/tests/test_commentjson.py
+++ b/commentjson/tests/test_commentjson.py
@@ -52,7 +52,11 @@ class TestCommentJson(unittest.TestCase):
                           Unserializable)
 
     def test_loads(self):
-        for index, test_json_ in self.test_json.iteritems():
+        try: #python2
+            test_iter = self.test_json.iteritems()
+        except AttributeError: #python3
+            test_iter = self.test_json.items()
+        for index, test_json_ in test_iter:
             commented = test_json_['commented']
             uncommented = test_json_['uncommented']
             assert commentjson.loads(commented) == json.loads(uncommented)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import sys
 from setuptools import setup, find_packages
 
 
-__version__ = '.'.join(map(str, (0, 5)))
+__version__ = '.'.join(map(str, (0, 5, 1)))
 
 install_requires = []
 if sys.version_info <= (2, 6):


### PR DESCRIPTION
It was not working in OS X either, so I took the liberty of making a few changes without breaking backward compatibility.

p.s.: @vaidik might like to set up [automatic deployment to pypi](http://docs.travis-ci.com/user/deployment/pypi/).
