### PR TITLE
Allow ValueError to pass-through without exception conversion.

### DIFF
--- a/commentjson/commentjson.py
+++ b/commentjson/commentjson.py
@@ -201,6 +201,10 @@ def load(fp, **kwargs):
 
     try:
         return loads(fp.read(), **kwargs)
+    except ValueError:
+        # pass through ValueError since that likely just indicates a bad
+        # JSON file and ValueError is how the json library signals that.
+        raise
     except Exception as e:
         raise JSONLibraryException(e)
 


### PR DESCRIPTION
This maintains compatibility with the Python json library which
raises ValueError when it cannot parse a file.