### PR TITLE
Add block comments

### DIFF
--- a/commentjson/commentjson.py
+++ b/commentjson/commentjson.py
@@ -45,7 +45,8 @@ parser = Lark('''
     pair   : string ":" value
     string : ESCAPED_STRING
 
-    COMMENT: /(#|\\/\\/)[^\\n]*/
+    COMMENT: "/*" /(.|\\n)+?/ "*/"
+           | /(#|\\/\\/)[^\\n]*/
     TRAILING_COMMA: ","
 
     %import common.ESCAPED_STRING

--- a/commentjson/tests/inline_has_special_characters-commented.json
+++ b/commentjson/tests/inline_has_special_characters-commented.json
@@ -7,6 +7,9 @@
             "name_cn": "机场",  # Has special characters
             "display": false
         },
+        /*
+        Special characters
+        */
         {
             "url": "text",
             "valueString": "ID for spørgeskemabesvarelse", # Danish

--- a/commentjson/tests/inline_last_float-commented.json
+++ b/commentjson/tests/inline_last_float-commented.json
@@ -6,3 +6,6 @@
     },
     "key3.2": 3.3 # testing comment
 }
+/*
+    testing comment
+*/

--- a/commentjson/tests/inline_last_int-commented.json
+++ b/commentjson/tests/inline_last_int-commented.json
@@ -1,5 +1,8 @@
+/*
+    testing comment
+*/
 {
-    "key1": 1,
+    "key1": 1, /* testing comment */
     "key2": "1",
     "key3": {
         "key3.1": 3 // testing comment

--- a/commentjson/tests/line_comment-commented.json
+++ b/commentjson/tests/line_comment-commented.json
@@ -4,4 +4,8 @@
     // A is supposed to be cool man
     // B is supposed to be cool man
     "a": 1
+    /*
+      # A is supposed to be cool man
+      // B is supposed to be cool man
+    */
 }

--- a/commentjson/tests/nested_object-commented.json
+++ b/commentjson/tests/nested_object-commented.json
@@ -5,6 +5,9 @@
     "key3.1": 3, // testing comment
     "key4": { # testing comment
         # Testing comment 1
+        /*
+            testing comment
+        */
         # Testing comment 2
         "key4_1": 1 # testing comment
     }, # testing comment

--- a/commentjson/tests/sample-commented.json
+++ b/commentjson/tests/sample-commented.json
@@ -11,6 +11,10 @@
             "3": "3"
         },
         "f": "some value" // some other stupid comment
+        /*
+            some other stupid comment
+            this time multine
+        */
     },
     "b": 2 # b inline comment
 }

--- a/commentjson/tests/string_with_inline_comment-commented.json
+++ b/commentjson/tests/string_with_inline_comment-commented.json
@@ -3,7 +3,9 @@
     "key2": "value2 has a // included.", // Real comment
     "key3": "value3 has a # included", // Real comment
     "nested": // Real comment
-    {
+    {  /*
+          testing comment
+       */
         "key4": "nested value4 is here", // Real comment
         "key5": "nested value5 has a // included.", // Real comment
         "key6": "nested value6 has a # included" // Real comment

--- a/commentjson/tests/trailing_comma-commented.json
+++ b/commentjson/tests/trailing_comma-commented.json
@@ -1,5 +1,7 @@
 {
-    "a": 1,
+    "a": 1, /*
+                testing comment
+            */
     "c": {
         # d is cool
         "d": "4.3",


### PR DESCRIPTION
This PR adds support for JavaScript-style block comments.

```
{
    "key": "value",
    /*
      comments like this
    */
    "another_key": "another_value"
}
```

, and block comments to the tests.