### PR TITLE
Update lark-parser to lark

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-lark-parser<0.8.0,>=0.7.1
+lark

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import setup, find_packages
 __version__ = '0.9.0'
 
 install_requires = [
-    'lark-parser>=0.7.1,<0.8.0'
+    'lark'
 ]
 if sys.version_info <= (2, 6):
     install_requires.append('simplejson')


### PR DESCRIPTION
The lark-parser has been renamed to lark.  The newest release seems
to be compatible with commentjson's code and all tests pass, so just
update the requirement.

Closes #51