### PR TITLE
Update test skips for Python 3.12+

### DIFF
--- a/commentjson/tests/test_json/test_decode.py
+++ b/commentjson/tests/test_json/test_decode.py
@@ -69,3 +69,8 @@ class TestCommentJsonDecode(TestDecode, CommentJsonTest):
                       'test case is not supported by commentjson.'))
     def test_negative_index(self):
         pass
+
+    @unittest.skipIf(version >= (3, 12),
+                     'Infinity as a value is not supported yet')
+    def test_parse_constant(self):
+        pass


### PR DESCRIPTION
Python 3.12 moves testing for `Infinity` and other constants into `test_json/test_decode.py::test_parse_constant`.